### PR TITLE
Miscellaneous fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(xdrfile C)
 
+if (POLICY CMP0063)
+    # Use of `<LANG>_VISIBILITY_PRESET` in OBJECT libraries
+    cmake_policy(SET CMP0063 NEW)
+endif()
+
 set(SOURCES
     src/xdrfile.c
     src/xdrfile_trr.c

--- a/include/xdrfile_trr.h
+++ b/include/xdrfile_trr.h
@@ -39,7 +39,7 @@ extern "C" {
  */
 
 /* This function returns the number of atoms in the xtc file in *natoms */
-extern int read_trr_natoms(char* fn, int* natoms);
+extern int read_trr_natoms(const char* fn, int* natoms);
 
 /* Read one frame of an open xtc file. If either of x,v,f,box are
    NULL the arrays will be read from the file but not used.  */

--- a/include/xdrfile_xtc.h
+++ b/include/xdrfile_xtc.h
@@ -40,7 +40,7 @@ extern "C" {
  */
 
 /* This function returns the number of atoms in the xtc file in *natoms */
-extern int read_xtc_natoms(char* fn, int* natoms);
+extern int read_xtc_natoms(const char* fn, int* natoms);
 
 /* Read one frame of an open xtc file */
 extern int read_xtc(XDRFILE* xd, int natoms, int* step, float* time, matrix box,

--- a/src/xdrfile.c
+++ b/src/xdrfile.c
@@ -844,6 +844,10 @@ int xdrfile_decompress_coord_float(float* ptr, int* size, float* precision,
             smallnum = magicints[smallidx] / 2;
         }
         sizesmall[0] = sizesmall[1] = sizesmall[2] = magicints[smallidx];
+        if (sizesmall[0] == 0 || sizesmall[1] == 0 || sizesmall[2] == 0) {
+            fprintf(stderr, "Invalid size found in 'xdrfile_decompress_coord_float'.\n");
+            return -1;
+        }
     }
     return *size;
 }
@@ -1323,6 +1327,10 @@ int xdrfile_decompress_coord_double(double* ptr, int* size, double* precision,
             smallnum = magicints[smallidx] / 2;
         }
         sizesmall[0] = sizesmall[1] = sizesmall[2] = magicints[smallidx];
+        if (sizesmall[0] == 0 || sizesmall[1] == 0 || sizesmall[2] == 0) {
+            fprintf(stderr, "Invalid size found in 'xdrfile_decompress_coord_double'.\n");
+            return -1;
+        }
     }
     return *size;
 }

--- a/src/xdrfile.c
+++ b/src/xdrfile.c
@@ -667,6 +667,7 @@ int xdrfile_decompress_coord_float(float* ptr, int* size, float* precision,
     float *lfp, inv_precision;
     int tmp, *thiscoord, prevcoord[3];
     unsigned int bitsize;
+    const float* ptrstart = ptr;
 
     bitsizeint[0] = 0;
     bitsizeint[1] = 0;
@@ -786,6 +787,10 @@ int xdrfile_decompress_coord_float(float* ptr, int* size, float* precision,
             is_smaller = run % 3;
             run -= is_smaller;
             is_smaller--;
+        }
+        if ((lfp - ptrstart) + run > size3) {
+            fprintf(stderr, "Buffer overrun during decompression.\n");
+            return -1;
         }
         if (run > 0) {
             thiscoord += 3;
@@ -1138,6 +1143,7 @@ int xdrfile_decompress_coord_double(double* ptr, int* size, double* precision,
     float float_prec, tmpdata[30];
     int tmp, *thiscoord, prevcoord[3];
     unsigned int bitsize;
+    const double* ptrstart = ptr;
 
     bitsizeint[0] = 0;
     bitsizeint[1] = 0;
@@ -1261,6 +1267,10 @@ int xdrfile_decompress_coord_double(double* ptr, int* size, double* precision,
             is_smaller = run % 3;
             run -= is_smaller;
             is_smaller--;
+        }
+        if ((lfp - ptrstart) + run > size3) {
+            fprintf(stderr, "Buffer overrun during decompression.\n");
+            return -1;
         }
         if (run > 0) {
             thiscoord += 3;

--- a/src/xdrfile_trr.c
+++ b/src/xdrfile_trr.c
@@ -474,7 +474,7 @@ static int do_trn(XDRFILE* xd, mybool bRead, int* step, float* t, float* lambda,
  *
  ************************************************************/
 
-int read_trr_natoms(char* fn, int* natoms) {
+int read_trr_natoms(const char* fn, int* natoms) {
     XDRFILE* xd;
     t_trnheader sh;
     int result;

--- a/src/xdrfile_xtc.c
+++ b/src/xdrfile_xtc.c
@@ -98,7 +98,7 @@ static int xtc_coord(
     return exdrOK;
 }
 
-int read_xtc_natoms(char* fn, int* natoms) {
+int read_xtc_natoms(const char* fn, int* natoms) {
     XDRFILE* xd;
     int step, result;
     float time;


### PR DESCRIPTION
Collection of some changes that seem to be good to have. Most of them are inspired by other xdrfile forks.

- Set cmake policy to get rid of annoying warning.
- Use `const char*` instead of `char*`. Makes use of `string` easier because of http://www.cplusplus.com/reference/string/string/c_str/
- There are some buffer overruns that are sadly not fixed in the official lib: https://mailman-1.sys.kth.se/pipermail/gromacs.org_gmx-developers/2014-September/007942.html
I also applied the fix for double precision trajectories.
- There are some reported instances where some values are 0 and this causes errors later on: https://github.com/mdtraj/mdtraj/issues/616